### PR TITLE
Add conda installation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ kopt is a hyper-parameter optimization library for Keras. It is based on [hypero
 pip install kopt
 ```
 
+Alternatively, Scprep can be installed using [Conda](https://conda.io/docs/) (most easily obtained via the [Miniconda Python distribution](https://conda.io/miniconda.html)):
+
+```bash
+conda install -c bioconda kopt
+```
+
 ## Getting started
 
 Here is an example of hyper-parameter optimization for the Keras IMDB

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ kopt is a hyper-parameter optimization library for Keras. It is based on [hypero
 pip install kopt
 ```
 
-Alternatively, Scprep can be installed using [Conda](https://conda.io/docs/) (most easily obtained via the [Miniconda Python distribution](https://conda.io/miniconda.html)):
+Alternatively, kopt can be installed using [Conda](https://conda.io/docs/) (most easily obtained via the [Miniconda Python distribution](https://conda.io/miniconda.html)):
 
 ```bash
 conda install -c bioconda kopt


### PR DESCRIPTION
Hi,

kopt is now available via conda and [bioconda](https://bioconda.github.io/recipes/kopt/README.html). With this PR, I added the information for installation via conda.

Bérénice